### PR TITLE
FIx Bitbucket download command + massive speed increase

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 const meow = require('meow');
-const { calculate, download, history, success, clean } = require('./');
+const { calculate, download, history, success, clean, cache } = require('./');
 
 async function main(argv) {
   const cli = meow({
@@ -16,6 +16,7 @@ async function main(argv) {
         history          List individual builds
         success          Get quick stats of number of success and failed builds
         clean            Delete the downloaded history of repository
+        cache            Outputs the directory where data will be cached
 
       Options
         --auth   [authentication]  (download) Authentication to access private repo
@@ -53,8 +54,11 @@ async function main(argv) {
         Display the number of success and failed builds
         $ build-stats travis:boltpkg/bolt success
 
-        Delete the downloaded history of repository 
+        Delete the downloaded history of repository
         $ build-stats travis:boltpkg/bolt clean
+
+        Ouptut the cache directory of a repository
+        $ build-stats travis:boltpkg/bolt cache
     `
   });
 
@@ -122,8 +126,10 @@ async function main(argv) {
       user,
       repo,
     });
+  } else if (command === 'cache') {
+    await cache({ cwd, host, user, repo });
   } else {
-    throw new Error(`Unknown command "${command}", should be "download", "calculate", "history", "success" or "clean"`);
+    throw new Error(`Unknown command "${command}", should be "download", "calculate", "history", "success", "clean", "cache"`);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -4,3 +4,4 @@ exports.calculate = require('./lib/commands/calculate');
 exports.download = require('./lib/commands/download');
 exports.history = require('./lib/commands/history');
 exports.success = require('./lib/commands/success');
+exports.cache = require('./lib/commands/cache');

--- a/lib/adapters/bitbucket.js
+++ b/lib/adapters/bitbucket.js
@@ -1,10 +1,13 @@
 'use strict';
+const chalk = require('chalk');
+const pLimit = require('p-limit');
 const got = require('got');
 const ora = require('ora');
 const path = require('path');
-const chalk = require('chalk');
 const { getBuildDir } = require('../utils/builds');
 const fs = require('../utils/fs');
+
+const baseUrl = (user, repo) => `https://api.bitbucket.org/2.0/repositories/${user}/${repo}/pipelines/`;
 
 function toStandardBuildConfig(build) {
   return {
@@ -18,50 +21,61 @@ function toStandardBuildConfig(build) {
   };
 }
 
+async function getTotalBuilds(user, repo) {
+  let res = await got(baseUrl(user, repo));
+  let resJson = JSON.parse(res.body);
+  return resJson.size;
+}
+
 async function fetchBitbucketPipelines(buildsDir, user, repo, auth, downloadHook) {
   let pagelen = 100;
-  let page = 1;
-  let totalBuilds = 0;
-  let buildsDownloaded = 0;
 
-  const spinner = ora({
-    text: `Starting download`
-  }).start();
+  // First check which files we already have
+  let currentlyDownloaded = await fs.readDir(buildsDir);
+  let lastDownloaded = currentlyDownloaded.filter(file => file.match(/^.+?\.json$/))
+    .map(file => file.replace('.json', ''))
+    .map(numStr => parseInt(numStr, 10))   // convert to integers
+    .sort((a, b) => a - b)                 // sort ascending (default sort )
+    .pop();                                // get the last (largest)
+  let startingBuild = lastDownloaded ? lastDownloaded + 1 : 1;
+  let totalBuilds = await getTotalBuilds(user, repo);
+  let startPage = Math.floor(startingBuild / pagelen) + 1;
+  let endPage = Math.floor(totalBuilds / pagelen) + 1;
 
-  outer:
-  do {
-    let res = await got(`https://api.bitbucket.org/2.0/repositories/${user}/${repo}/pipelines/?pagelen=${pagelen}&page=${page}&sort=-created_on`, {
-      auth
-    });
-    let json = JSON.parse(res.body);
-    let builds = json.values;
-    totalBuilds = json.size;
+  let limit = pLimit(10); // limits us to running no more than 10 at a time
+  let downloaded = startingBuild - 1;
+  let spinner = ora().start('Starting download');
 
-    for (let build of builds) {
-      let date = new Date();
-      let filePath = path.join(buildsDir, `${build.build_number}.json`);
+  let requestPromises = [];
+  for (let page = startPage; page <= endPage; page++) {
+    let url = `${baseUrl(user, repo)}?pagelen=${pagelen}&page=${page}&sort=created_on`;
+    requestPromises.push(limit(async () => {
+      let res = await got(url, { auth });
+      let resJson = JSON.parse(res.body);
+      let builds = resJson.values;
 
-      if (await fs.exists(filePath)) {
-        break outer;
-      }
+      let writeFilePromises = builds.map((build) => {
+        let date = new Date();
+        let filePath = path.join(buildsDir, `${build.build_number}.json`);
 
-      if (build.state.name !== 'COMPLETED' || build.trigger.name === 'SCHEDULE') {
-        continue;
-      }
+        if (build.state.name !== 'COMPLETED' || build.trigger.name === 'SCHEDULE') {
+          return Promise.resolve();
+        }
+        build = toStandardBuildConfig(build);
 
-      build = toStandardBuildConfig(build);
+        return fs.writeFile(filePath, JSON.stringify(build));
+      });
 
-      await fs.writeFile(filePath, JSON.stringify(build));
-    }
+      await Promise.all(writeFilePromises);
 
-    buildsDownloaded = Math.min(json.page * pagelen, totalBuilds);
-    downloadHook && downloadHook(
-      buildsDownloaded,
-      totalBuilds);
-    page++;
+      downloaded += builds.length;
+      spinner.text = chalk`Downloaded data for {green ${downloaded}} builds of {green ${totalBuilds}} builds`;
+      downloadHook && downloadHook(downloaded, totalBuilds);
+    }));
+  }
 
-    spinner.text = chalk`Downloaded data for {green ${buildsDownloaded}} builds of {green ${totalBuilds}} builds`;
-  } while (buildsDownloaded < totalBuilds);
+  await Promise.all(requestPromises);
+
   spinner.succeed(chalk`Download completed. Total Builds: {green ${totalBuilds}}`);
 }
 

--- a/lib/commands/cache.js
+++ b/lib/commands/cache.js
@@ -1,0 +1,10 @@
+const { getBuildDir } = require('../utils/builds');
+
+async function cache({ cwd, host, user, repo }) {
+  const cacheDir = await getBuildDir(cwd, host, user, repo);
+  console.log(cacheDir);
+  // returning since these commands are also exposed from the index.js file
+  return cacheDir;
+}
+
+module.exports = cache;

--- a/lib/utils/builds.js
+++ b/lib/utils/builds.js
@@ -5,18 +5,11 @@ const times = require('./times');
 const defaultBuildDir = path.join(__dirname,'../..');
 
 async function getBuildDir(cwd = defaultBuildDir, host, user, repo) {
-  let dataDir = path.join(cwd, '.data');
-  await fs.ensureDir(dataDir);
-  let hostDir = path.join(dataDir, host);
-  await fs.ensureDir(hostDir);
-  let userDir = path.join(hostDir, user);
-  await fs.ensureDir(userDir);
-  let repoDir = path.join(userDir, repo);
-  await fs.ensureDir(repoDir);
-  let buildsDir = path.join(repoDir, 'builds');
-  await fs.ensureDir(buildsDir);
+  const buildsDir = path.join(cwd, '.data', host, user, repo, 'builds');
+  await fs.mkdirp(buildsDir);
   return buildsDir;
 };
+
 
 async function getHistory(cwd, host, user, repo, filters) {
   let buildsDir = await getBuildDir(cwd, host, user, repo);

--- a/lib/utils/fs.js
+++ b/lib/utils/fs.js
@@ -1,10 +1,11 @@
 'use strict';
 const fs = require('fs');
-const mkdirp = require('mkdirp');
+const mkdirpFn = require('mkdirp');
 const path = require('path');
 const { promisify } = require('util');
 
 const mkdir = promisify(fs.mkdir);
+const mkdirp = promisify(mkdirpFn);
 const readDir = promisify(fs.readdir);
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);

--- a/lib/utils/fs.js
+++ b/lib/utils/fs.js
@@ -1,5 +1,6 @@
 'use strict';
 const fs = require('fs');
+const mkdirp = require('mkdirp');
 const path = require('path');
 const { promisify } = require('util');
 
@@ -9,15 +10,6 @@ const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 const stat = promisify(fs.stat);
 
-async function ensureDir(dirName) {
-  try {
-    await mkdir(dirName);
-  } catch (err) {
-    if (err.code !== 'EEXIST') {
-      throw err;
-    }
-  }
-}
 
 async function exists(filePath) {
   try {
@@ -37,6 +29,6 @@ module.exports = {
   readFile,
   writeFile,
   stat,
-  ensureDir,
+  mkdirp,
   exists,
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "left-pad": "^1.2.0",
     "lodash.groupby": "^4.6.0",
     "meow": "^4.0.0",
+    "mkdirp": "^0.5.1",
     "ora": "^1.4.0",
     "rimraf-promise": "^2.0.0",
     "string-to-stream": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "meow": "^4.0.0",
     "mkdirp": "^0.5.1",
     "ora": "^1.4.0",
+    "p-limit": "^2.0.0",
     "rimraf-promise": "^2.0.0",
     "string-to-stream": "^1.1.0"
   },

--- a/test/utils/fs.test.js
+++ b/test/utils/fs.test.js
@@ -7,5 +7,4 @@ test.todo('fs.readDir');
 test.todo('fs.readFile');
 test.todo('fs.writeFile');
 test.todo('fs.stat');
-test.todo('fs.ensureDir');
 test.todo('fs.exists');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,9 +2103,15 @@ minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.1:
+"mkdirp@>=0.5 0":
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  dependencies:
+    minimist "0.0.8"
+
+mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,13 +2103,7 @@ minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-"mkdirp@>=0.5 0":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@^0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2291,6 +2285,12 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -2306,6 +2306,10 @@ p-timeout@^2.0.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 package-hash@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Fixes #15 

There was a bug that would cause long running downloads of BB repo stats to fail. It turned out to be because we were fetching backwards, so when a new build started, the pagination would be off by  causing a build to be downloaded when it already existed, causing the script to think it was done downloading.

The fix here is to do the requests in ascending order, so that pagination can not change.

I also made it make the requests in parallel using p-limit, speeding it up tons.

**Future**

* Would be good to add  `--concurrency` flag to control the pLimit var. Not sure what a good default is, I went with 10
* Would be good to have a `--from` flag that overrides the check that makes us start from the last downloaded file. This would mainly be a safety measure for if builds failed for some reason. This gives you a way to always recover
* We should do this same change for travis 