### PR TITLE
Fixes bug in Bitbucket downloading and adds massive speedup

### DIFF
--- a/lib/adapters/bitbucket.js
+++ b/lib/adapters/bitbucket.js
@@ -1,10 +1,13 @@
 'use strict';
+const chalk = require('chalk');
+const pLimit = require('p-limit');
 const got = require('got');
 const ora = require('ora');
 const path = require('path');
-const chalk = require('chalk');
 const { getBuildDir } = require('../utils/builds');
 const fs = require('../utils/fs');
+
+const baseUrl = (user, repo) => `https://api.bitbucket.org/2.0/repositories/${user}/${repo}/pipelines/`;
 
 function toStandardBuildConfig(build) {
   return {
@@ -18,50 +21,61 @@ function toStandardBuildConfig(build) {
   };
 }
 
+async function getTotalBuilds(user, repo) {
+  let res = await got(baseUrl(user, repo));
+  let resJson = JSON.parse(res.body);
+  return resJson.size;
+}
+
 async function fetchBitbucketPipelines(buildsDir, user, repo, auth, downloadHook) {
   let pagelen = 100;
-  let page = 1;
-  let totalBuilds = 0;
-  let buildsDownloaded = 0;
 
-  const spinner = ora({
-    text: `Starting download`
-  }).start();
+  // First check which files we already have
+  let currentlyDownloaded = await fs.readDir(buildsDir);
+  let lastDownloaded = currentlyDownloaded.filter(file => file.match(/^.+?\.json$/))
+    .map(file => file.replace('.json', ''))
+    .map(numStr => parseInt(numStr, 10))   // convert to integers
+    .sort((a, b) => a - b)                 // sort ascending (default sort )
+    .pop();                                // get the last (largest)
+  let startingBuild = lastDownloaded ? lastDownloaded + 1 : 1;
+  let totalBuilds = await getTotalBuilds(user, repo);
+  let startPage = Math.floor(startingBuild / pagelen) + 1;
+  let endPage = Math.floor(totalBuilds / pagelen) + 1;
 
-  outer:
-  do {
-    let res = await got(`https://api.bitbucket.org/2.0/repositories/${user}/${repo}/pipelines/?pagelen=${pagelen}&page=${page}&sort=-created_on`, {
-      auth
-    });
-    let json = JSON.parse(res.body);
-    let builds = json.values;
-    totalBuilds = json.size;
+  let limit = pLimit(10); // limits us to running no more than 10 at a time
+  let downloaded = startingBuild - 1;
+  let spinner = ora().start('Starting download');
 
-    for (let build of builds) {
-      let date = new Date();
-      let filePath = path.join(buildsDir, `${build.build_number}.json`);
+  let requestPromises = [];
+  for (let page = startPage; page <= endPage; page++) {
+    let url = `${baseUrl(user, repo)}?pagelen=${pagelen}&page=${page}&sort=created_on`;
+    requestPromises.push(limit(async () => {
+      let res = await got(url, { auth });
+      let resJson = JSON.parse(res.body);
+      let builds = resJson.values;
 
-      if (await fs.exists(filePath)) {
-        break outer;
-      }
+      let writeFilePromises = builds.map((build) => {
+        let date = new Date();
+        let filePath = path.join(buildsDir, `${build.build_number}.json`);
 
-      if (build.state.name !== 'COMPLETED' || build.trigger.name === 'SCHEDULE') {
-        continue;
-      }
+        if (build.state.name !== 'COMPLETED' || build.trigger.name === 'SCHEDULE') {
+          return Promise.resolve();
+        }
+        build = toStandardBuildConfig(build);
 
-      build = toStandardBuildConfig(build);
+        return fs.writeFile(filePath, JSON.stringify(build));
+      });
 
-      await fs.writeFile(filePath, JSON.stringify(build));
-    }
+      await Promise.all(writeFilePromises);
 
-    buildsDownloaded = Math.min(json.page * pagelen, totalBuilds);
-    downloadHook && downloadHook(
-      buildsDownloaded,
-      totalBuilds);
-    page++;
+      downloaded += builds.length;
+      spinner.text = chalk`Downloaded data for {green ${downloaded}} builds of {green ${totalBuilds}} builds`;
+      downloadHook && downloadHook(downloaded, totalBuilds);
+    }));
+  }
 
-    spinner.text = chalk`Downloaded data for {green ${buildsDownloaded}} builds of {green ${totalBuilds}} builds`;
-  } while (buildsDownloaded < totalBuilds);
+  await Promise.all(requestPromises);
+
   spinner.succeed(chalk`Download completed. Total Builds: {green ${totalBuilds}}`);
 }
 

--- a/lib/utils/fs.js
+++ b/lib/utils/fs.js
@@ -1,10 +1,11 @@
 'use strict';
 const fs = require('fs');
-const mkdirp = require('mkdirp');
+const mkdirpFn = require('mkdirp');
 const path = require('path');
 const { promisify } = require('util');
 
 const mkdir = promisify(fs.mkdir);
+const mkdirp = promisify(mkdirpFn);
 const readDir = promisify(fs.readdir);
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "meow": "^4.0.0",
     "mkdirp": "^0.5.1",
     "ora": "^1.4.0",
+    "p-limit": "^2.0.0",
     "rimraf-promise": "^2.0.0",
     "string-to-stream": "^1.1.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,13 +2103,7 @@ minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-"mkdirp@>=0.5 0":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  dependencies:
-    minimist "0.0.8"
-
-mkdirp@^0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2291,6 +2285,12 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
+p-limit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -2306,6 +2306,10 @@ p-timeout@^2.0.1:
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+
+p-try@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.0.0.tgz#85080bb87c64688fa47996fe8f7dfbe8211760b1"
 
 package-hash@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Fixes #16

There was a bug that would cause long running downloads of BB repo stats to fail. It turned out to be because we were fetching backwards, so when a new build started, the pagination would be off by causing a build to be downloaded when it already existed, causing the script to think it was done downloading.

The fix here is to do the requests in ascending order, so that pagination can not change.

I also made it make the requests in parallel using p-limit, speeding it up tons.

**Future**

* Would be good to add --concurrency flag to control the pLimit var. Not sure what a good default is, I went with 10 (#22)
* Would be good to have a --from flag that overrides the check that makes us start from the last downloaded file. This would mainly be a safety measure for if builds failed for some reason. This gives you a way to always recover (#20 )
* We should do this same change for travis (#21)
